### PR TITLE
fix: install libstdc++-dev explicitly to survive apt autoremove

### DIFF
--- a/deploy/tdlib.dockerfile
+++ b/deploy/tdlib.dockerfile
@@ -4,7 +4,7 @@ ARG TDLIB_COMMIT=971684a
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        zlib1g-dev libssl-dev gperf php-cli cmake g++ && \
+        zlib1g-dev libssl-dev gperf php-cli cmake g++ libstdc++-dev && \
     git clone https://github.com/tdlib/td.git /tmp/td && \
     cd /tmp/td && git checkout ${TDLIB_COMMIT} && \
     mkdir build && cd build && \


### PR DESCRIPTION
After purging g++, apt autoremove removes libstdc++-dev (pulled in as a dependency), causing the linker to fail with "cannot find -lstdc++" when building the render test binary. Explicitly installing libstdc++-dev marks it as manually installed so autoremove leaves it.

https://claude.ai/code/session_01CGRdutnchDxDvPoXsgp8v6


- [ ] test check